### PR TITLE
Feat: Reduce cancellation token noise

### DIFF
--- a/demo/Crud/Crud.Core/Users.cs
+++ b/demo/Crud/Crud.Core/Users.cs
@@ -28,9 +28,9 @@ namespace Crud.Core
         {
             var initModel = new Model(RecordList<User>.Empty, false);
             return (initModel,
-                async (mediator, dispatch, token) =>
+                async (mediator, dispatch) =>
                 {
-                    var list = (await mediator.SendAsync(new Request.GetAll<User>(), token)).ToRecordList();
+                    var list = (await mediator.SendAsync(new Request.GetAll<User>())).ToRecordList();
                     if (list.Count != 0)
                     {
                         dispatch(new Msg.Set(initModel with {Users = list}));
@@ -45,10 +45,10 @@ namespace Crud.Core
             {
                 case Msg.Add addMsg:
                     return (model,
-                        async (mediator, dispatch, token) =>
+                        async (mediator, dispatch) =>
                         {
-                            await mediator.SendAsync(new Request.Add<User>(addMsg.UserToAdd), token);
-                            if (await mediator.SendAsync(new Request.SaveChanges(), token))
+                            await mediator.SendAsync(new Request.Add<User>(addMsg.UserToAdd));
+                            if (await mediator.SendAsync(new Request.SaveChanges()))
                             {
                                 dispatch(new Msg.Set(model with {
                                     Users = list.Add(addMsg.UserToAdd),
@@ -60,10 +60,10 @@ namespace Crud.Core
                     var user = list.Find(u => u.Id == id.Id);
                     var request = new Request.Delete<User>(user);
                     return (model,
-                        async (mediator, dispatch, token) =>
+                        async (mediator, dispatch) =>
                         {
-                            await mediator.SendAsync(request, token);
-                            if (await mediator.SendAsync(new Request.SaveChanges(), token))
+                            await mediator.SendAsync(request);
+                            if (await mediator.SendAsync(new Request.SaveChanges()))
                             {
                                 dispatch(new Msg.Set(model with {Users = list.Remove(user)}));
                             }

--- a/src/MvuSharp.Core/Command.cs
+++ b/src/MvuSharp.Core/Command.cs
@@ -6,12 +6,12 @@ namespace MvuSharp
 {
 	public delegate void DispatchHandler<in TMsg>(TMsg msg);
 	
-	public delegate Task CommandHandler<out TMsg>(IMediator mediator, DispatchHandler<TMsg> dispatchHandler, CancellationToken cancellationToken);	
+	public delegate Task CommandHandler<out TMsg>(IMediator mediator, DispatchHandler<TMsg> dispatchHandler);	
 	
 	public static class Command
 	{
 		public static CommandHandler<TMsg> OfMsg<TMsg>(TMsg msg) =>
-			(_, dispatch, _) => 
+			(_, dispatch) => 
 			{
 				dispatch(msg);
 				return Task.CompletedTask;
@@ -20,9 +20,9 @@ namespace MvuSharp
 		public static CommandHandler<TMsg> MapResult<TMsg, TResult>(
 			IRequest<TResult> request, 
 			Func<TResult, TMsg> mapFunc) =>
-			async (mediator, dispatch, token) =>
+			async (mediator, dispatch) =>
 			{
-				var response = await mediator.SendAsync(request, token);
+				var response = await mediator.SendAsync(request);
 				dispatch(mapFunc(response));
 			};
 
@@ -30,11 +30,11 @@ namespace MvuSharp
 			IRequest<TResult> request,
 			Action<TResult> onSuccess,
 			Action<Exception> onFailure) =>
-			async (mediator, _, token) =>
+			async (mediator, _) =>
 			{
 				try
 				{
-					var result = await mediator.SendAsync(request, token);
+					var result = await mediator.SendAsync(request);
 					onSuccess(result);
 				}
 				catch (Exception exception)

--- a/src/MvuSharp.Core/HandlerRegistrar.cs
+++ b/src/MvuSharp.Core/HandlerRegistrar.cs
@@ -79,7 +79,7 @@ namespace MvuSharp
                     ? this
                     : throw new ArgumentException($"$Unexpected service type: {type.FullName}");
 
-            return new Mediator(serviceFactory);
+            return new Mediator(serviceFactory, CancellationToken.None);
         }
     }
 }

--- a/src/MvuSharp.Core/IMediator.cs
+++ b/src/MvuSharp.Core/IMediator.cs
@@ -5,7 +5,7 @@ namespace MvuSharp
 {
     public interface IMediator
     {
-        Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken);
-        Task SendAsync(IRequest request, CancellationToken cancellationToken);
+        Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request);
+        Task SendAsync(IRequest request);
     }
 }

--- a/src/MvuSharp.Core/Internal/Mediator.cs
+++ b/src/MvuSharp.Core/Internal/Mediator.cs
@@ -6,24 +6,25 @@ namespace MvuSharp.Internal
     internal class Mediator : IMediator
     {
         private readonly ServiceFactory _factory;
+        private readonly CancellationToken _cancellationToken;
         private readonly HandlerRegistrar _handlers;
 
-        public Mediator(ServiceFactory serviceFactory)
+        public Mediator(ServiceFactory serviceFactory, CancellationToken cancellationToken)
         {
             _factory = serviceFactory;
+            _cancellationToken = cancellationToken;
             _handlers = serviceFactory.GetService<HandlerRegistrar>();
         }
 
-        public async Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request,
-            CancellationToken cancellationToken)
+        public async Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request)
         {
             return await ((RequestHandlerWrapper<TResponse>) _handlers[request.GetType()])
-                .RunAsync(request, _factory, cancellationToken);
+                .RunAsync(request, _factory, _cancellationToken);
         }
 
-        public async Task SendAsync(IRequest request, CancellationToken cancellationToken)
+        public async Task SendAsync(IRequest request)
         {
-            await SendAsync<Unit>(request, cancellationToken);
+            await SendAsync<Unit>(request);
         }
     }
 }

--- a/src/MvuSharp.Core/MvuProgram.cs
+++ b/src/MvuSharp.Core/MvuProgram.cs
@@ -26,10 +26,10 @@ namespace MvuSharp
             _viewEngine = viewEngine ?? throw new ArgumentNullException(nameof(viewEngine));
         }
 
-        private IMediator CreateMediator()
+        private IMediator CreateMediator(CancellationToken cancellationToken)
         {
             var scope = _serviceProvider.CreateScope();
-            return new Mediator(scope.ServiceProvider.GetService);
+            return new Mediator(scope.ServiceProvider.GetService, cancellationToken);
         }
 
         public async Task InitAsync()
@@ -47,9 +47,9 @@ namespace MvuSharp
                 return;
             }
 
-            var mediator = CreateMediator();
+            var mediator = CreateMediator(CancellationToken.None);
             var msgQueue = new Queue<TMsg>();
-            await cmd(mediator, msgQueue.Enqueue, default);
+            await cmd(mediator, msgQueue.Enqueue);
             await MsgLoopAsync(msgQueue, default, mediator);
         }
 
@@ -86,10 +86,10 @@ namespace MvuSharp
                 await _viewEngine.RenderViewAsync(model);
 
                 if (cmd == null) continue;
-                mediator ??= CreateMediator();
+                mediator ??= CreateMediator(cancellationToken);
                 try
                 {
-                    await cmd(mediator, dispatchHandler, cancellationToken);
+                    await cmd(mediator, dispatchHandler);
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/MvuSharp.Testing/IMediatorExtensions.cs
+++ b/src/MvuSharp.Testing/IMediatorExtensions.cs
@@ -26,7 +26,7 @@ namespace MvuSharp.Testing
             Action<IEnumerable<TMsg>> assertMsg)
         {
             var msgList = new LinkedList<TMsg>();
-            command(mediator, msg => msgList.AddLast(msg), default).Wait();
+            command(mediator, msg => msgList.AddLast(msg)).Wait();
             assertMsg(msgList);
         }
     }


### PR DESCRIPTION
It seems to me that it is unnecessary to pass the cancellation token to the command handler, given that only the Mediator makes use of it. I propose to store the cancellation token in the Mediator instead.